### PR TITLE
link to the google group

### DIFF
--- a/app/assets/stylesheets/generic/typography.css.sass
+++ b/app/assets/stylesheets/generic/typography.css.sass
@@ -12,7 +12,7 @@ i, em
 
 a
   color: white
-  text-decoration: none
+  text-decoration: underline
 
 h1
   font-size: 24px

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -15,7 +15,7 @@
       We are a group of Developers looking to build a Swiss-wide community of Rubyists. Join the movement and attend our next meetup. Let your colleagues know about Ruvetia and if you want to bring Ruvetia to your city feel free to drop us a note.
     </p>
     <p>
-      Currently we will be communicating everything through the Google Group so make sure to subscribe.
+      Currently we will be communicating everything through the <%= link_to 'Google Group', 'https://groups.google.com/forum/?fromgroups#!forum/ruvetia' %> so make sure to subscribe.
     </p>
   </div>
 </div>


### PR DESCRIPTION
As long as we won't have #2 we should link to the group. Perhaps with a shiny button? Or just link the text?

For the time being I just linked the text. I had to modify the link color to generate som contrast.
