### PR TITLE
bugfix, allow github users without name

### DIFF
--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -24,7 +24,7 @@ class Member < ActiveRecord::Base
 
   def self.from_github_data(token, data)
     user = find_by_github_id(data["id"])
-    user ||= Member.create!(name: data["name"],
+    user ||= Member.create!(name: data.fetch("name", data["login"]),
                             email: data["email"],
                             github_id: data["id"],
                             github_login: data["login"],

--- a/test/models/member_test.rb
+++ b/test/models/member_test.rb
@@ -50,6 +50,20 @@ class MemberTest < ActiveSupport::TestCase
     assert_equal token, member.github_oauth_token
   end
 
+  test "can be created when no name is specified on github" do
+    data = {
+            "id" => 2384,
+            "login" => "danielpuglisi",
+            "email" => "daniel.puglisi@gmx.net",
+           }
+    token = "asjd23akjdh191hd938h8hf84"
+    member = Member.from_github_data(token, data)
+
+    assert_not member.new_record?
+    assert_equal "danielpuglisi", member.github_login
+    assert_equal "danielpuglisi", member.name
+  end
+
   test "does not create duplicate users" do
     Member.create(name: "Rodrigo", github_id: 378)
 


### PR DESCRIPTION
If you don't set your Name on Github the sign-up process used to crash. This patch simply uses the github login as name when we don't have a name.
